### PR TITLE
Switching from CGLib proxies to Javassist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 .classpath
 .project
 .settings
+/bin/

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,6 @@
 
   :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
                  [amazonica "0.3.156" :scope "provided"]
-                 [cglib "3.3.0"]
                  [org.javassist/javassist "3.28.0-GA"]]
 
   :lein-release {:deploy-via :clojars}

--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,8 @@
         :url  "https://github.com/biiwide/sandboxica"}
 
   :plugins [[lein-ancient "0.7.0"]
+            [lein-cloverage "1.2.2"]
+            [lein-eftest "0.5.9"]
             [lein-file-replace "0.1.0"]]
 
   :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
@@ -19,7 +21,13 @@
 
   :lein-release {:deploy-via :clojars}
 
+  :cloverage {:runner :eftest
+              :runner-opts {:multithread? :vars}}
+
+  :eftest {:multithread? :vars}
+
   :profiles {:dev {:dependencies [[com.amazonaws/aws-java-sdk-s3 "1.11.993"]
+                                  [eftest "0.5.9"]
                                   [nubank/matcher-combinators "3.2.1"]]}}
 
   :release-tasks [["vcs" "assert-committed"]

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
   :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
                  [amazonica "0.3.156" :scope "provided"]
                  [cglib "3.3.0"]
-                 [javassist/javassist "3.12.1.GA"]]
+                 [org.javassist/javassist "3.28.0-GA"]]
 
   :lein-release {:deploy-via :clojars}
 

--- a/project.clj
+++ b/project.clj
@@ -15,12 +15,13 @@
 
   :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
                  [amazonica "0.3.156" :scope "provided"]
-                 [cglib "3.3.0"]]
+                 [cglib "3.3.0"]
+                 [javassist/javassist "3.12.1.GA"]]
 
   :lein-release {:deploy-via :clojars}
 
   :profiles {:dev {:dependencies [[com.amazonaws/aws-java-sdk-s3 "1.11.993"]
-                                  [nubank/matcher-combinators "1.0.0"]]}}
+                                  [nubank/matcher-combinators "3.2.1"]]}}
 
   :release-tasks [["vcs" "assert-committed"]
                   ["change" "version" "leiningen.release/bump-version" "release"]

--- a/test/biiwide/sandboxica/alpha_test.clj
+++ b/test/biiwide/sandboxica/alpha_test.clj
@@ -16,26 +16,15 @@
             [com.amazonaws.services.sqs.model
              DeleteMessageResult SendMessageRequest SendMessageResult]
             [java.lang.reflect Method Modifier]
-            [javassist.util.proxy MethodHandler]
-            [net.sf.cglib.proxy Callback CallbackFilter
-             Enhancer InvocationHandler]))
+            [javassist.util.proxy MethodHandler]))
 
 
-(deftest test-cglib-invocation-handler
-  (is (instance?
-        InvocationHandler
-        (sandbox/cglib-invocation-handler [_ _] nil)))
-  (let [o (Object.)]
-    (is (identical? o (.invoke (sandbox/cglib-invocation-handler [_ _] o)
-                               nil nil nil)))))
-
-
-(deftest test-javassist-invocation-handler
+(deftest test-invocation-handler
   (is (instance?
         MethodHandler
-        (sandbox/javassist-invocation-handler [_ _] nil)))
+        (sandbox/invocation-handler [_ _] nil)))
   (let [o (Object.)]
-    (is (identical? o (.invoke (sandbox/javassist-invocation-handler [_ _] o)
+    (is (identical? o (.invoke (sandbox/invocation-handler [_ _] o)
                                nil nil nil nil)))))
 
 
@@ -60,35 +49,10 @@
          (is (= "def" (.getAWSSecretKey creds))))))
 
 
-(deftest test-cglib-client-proxy
+(deftest test-client-proxy
   (are [client-class endpoint-prefix service-name]
-       (let [proxy (#'sandbox/cglib-client-proxy client-class
-                     (sandbox/cglib-invocation-handler [_ _]
-                       (throw (RuntimeException. "BOOM!"))))]
-         (and (is (instance? client-class proxy))
-              (is (= endpoint-prefix (.getEndpointPrefix proxy)))
-              (is (= service-name (.getServiceName proxy)))
-              ))
-
-       com.amazonaws.services.apigateway.AmazonApiGatewayClient "apigateway" "apigateway"
-       com.amazonaws.services.athena.AmazonAthenaClient         "athena"     "athena"
-       com.amazonaws.services.config.AmazonConfigClient         "config"     "config"
-       com.amazonaws.services.ec2.AmazonEC2Client               "ec2"        "ec2"
-       com.amazonaws.services.ecs.AmazonECSClient               "ecs"        "ecs"
-       com.amazonaws.services.glacier.AmazonGlacierClient       "glacier"    "glacier"
-       com.amazonaws.services.kafka.AWSKafkaClient              "kafka"      "kafka"
-       com.amazonaws.services.kinesis.AmazonKinesisClient       "kinesis"    "kinesis"
-       com.amazonaws.services.s3.AmazonS3Client                 "s3"         "s3"
-       com.amazonaws.services.sns.AmazonSNSClient               "sns"        "sns"
-       com.amazonaws.services.sqs.AmazonSQSClient               "sqs"        "sqs"
-       com.amazonaws.services.transfer.AWSTransferClient        "transfer"   "transfer"
-       ))
-
-
-(deftest test-javassist-client-proxy
-  (are [client-class endpoint-prefix service-name]
-       (let [proxy (#'sandbox/javassist-client-proxy client-class
-                     (sandbox/javassist-invocation-handler [_ _]
+       (let [proxy (#'sandbox/client-proxy client-class
+                     (sandbox/invocation-handler [_ _]
                        (throw (RuntimeException. "BOOM!"))))]
          (and (is (instance? client-class proxy))
               (is (= endpoint-prefix (.getEndpointPrefix proxy)))

--- a/test/biiwide/sandboxica/alpha_test.clj
+++ b/test/biiwide/sandboxica/alpha_test.clj
@@ -16,6 +16,7 @@
             [com.amazonaws.services.sqs.model
              DeleteMessageResult SendMessageRequest SendMessageResult]
             [java.lang.reflect Method Modifier]
+            [javassist.util.proxy MethodHandler]
             [net.sf.cglib.proxy Callback CallbackFilter
              Enhancer InvocationHandler]))
 
@@ -27,6 +28,15 @@
   (let [o (Object.)]
     (is (identical? o (.invoke (sandbox/cglib-invocation-handler [_ _] o)
                                nil nil nil)))))
+
+
+(deftest test-javassist-invocation-handler
+  (is (instance?
+        MethodHandler
+        (sandbox/javassist-invocation-handler [_ _] nil)))
+  (let [o (Object.)]
+    (is (identical? o (.invoke (sandbox/javassist-invocation-handler [_ _] o)
+                               nil nil nil nil)))))
 
 
 (deftest test-sync-client-params
@@ -54,6 +64,31 @@
   (are [client-class endpoint-prefix service-name]
        (let [proxy (#'sandbox/cglib-client-proxy client-class
                      (sandbox/cglib-invocation-handler [_ _]
+                       (throw (RuntimeException. "BOOM!"))))]
+         (and (is (instance? client-class proxy))
+              (is (= endpoint-prefix (.getEndpointPrefix proxy)))
+              (is (= service-name (.getServiceName proxy)))
+              ))
+
+       com.amazonaws.services.apigateway.AmazonApiGatewayClient "apigateway" "apigateway"
+       com.amazonaws.services.athena.AmazonAthenaClient         "athena"     "athena"
+       com.amazonaws.services.config.AmazonConfigClient         "config"     "config"
+       com.amazonaws.services.ec2.AmazonEC2Client               "ec2"        "ec2"
+       com.amazonaws.services.ecs.AmazonECSClient               "ecs"        "ecs"
+       com.amazonaws.services.glacier.AmazonGlacierClient       "glacier"    "glacier"
+       com.amazonaws.services.kafka.AWSKafkaClient              "kafka"      "kafka"
+       com.amazonaws.services.kinesis.AmazonKinesisClient       "kinesis"    "kinesis"
+       com.amazonaws.services.s3.AmazonS3Client                 "s3"         "s3"
+       com.amazonaws.services.sns.AmazonSNSClient               "sns"        "sns"
+       com.amazonaws.services.sqs.AmazonSQSClient               "sqs"        "sqs"
+       com.amazonaws.services.transfer.AWSTransferClient        "transfer"   "transfer"
+       ))
+
+
+(deftest test-javassist-client-proxy
+  (are [client-class endpoint-prefix service-name]
+       (let [proxy (#'sandbox/javassist-client-proxy client-class
+                     (sandbox/javassist-invocation-handler [_ _]
                        (throw (RuntimeException. "BOOM!"))))]
          (and (is (instance? client-class proxy))
               (is (= endpoint-prefix (.getEndpointPrefix proxy)))

--- a/test/biiwide/sandboxica/alpha_test.clj
+++ b/test/biiwide/sandboxica/alpha_test.clj
@@ -20,12 +20,12 @@
              Enhancer InvocationHandler]))
 
 
-(deftest test-invocation-handler
+(deftest test-cglib-invocation-handler
   (is (instance?
         InvocationHandler
-        (sandbox/invocation-handler [_ _] nil)))
+        (sandbox/cglib-invocation-handler [_ _] nil)))
   (let [o (Object.)]
-    (is (identical? o (.invoke (sandbox/invocation-handler [_ _] o)
+    (is (identical? o (.invoke (sandbox/cglib-invocation-handler [_ _] o)
                                nil nil nil)))))
 
 
@@ -50,10 +50,10 @@
          (is (= "def" (.getAWSSecretKey creds))))))
 
 
-(deftest test-client-proxy
+(deftest test-cglib-client-proxy
   (are [client-class endpoint-prefix service-name]
-       (let [proxy (#'sandbox/client-proxy client-class
-                     (sandbox/invocation-handler [_ _]
+       (let [proxy (#'sandbox/cglib-client-proxy client-class
+                     (sandbox/cglib-invocation-handler [_ _]
                        (throw (RuntimeException. "BOOM!"))))]
          (and (is (instance? client-class proxy))
               (is (= endpoint-prefix (.getEndpointPrefix proxy)))
@@ -230,5 +230,6 @@
   (sandbox/with (sandbox/just
                  (s3/put-object [req]
                    (is (match? (assoc put-req :input-stream content)
-                               (update req :input-stream slurp)))))
+                               (update req :input-stream slurp)))
+                   {}))
     (s3/put-object {:profile "none"} put-req))))


### PR DESCRIPTION
CGLib will not be updated to support the reflection changes in Java 13 and beyond.
I tried using both ByteBuddy and Javassist, and decided on Javassist since it's API was very similar to CGLib's API.